### PR TITLE
4.0.0: tuning create calls to make sure no limit issues

### DIFF
--- a/autochannel/__init__.py
+++ b/autochannel/__init__.py
@@ -1,5 +1,5 @@
 """
 init - version info
 """
-VERSION_INFO = (3, 2, 1)
+VERSION_INFO = (4, 0, 0)
 VERSION = '.'.join(str(c) for c in VERSION_INFO)

--- a/autochannel/lib/plugins/autochannels.py
+++ b/autochannel/lib/plugins/autochannels.py
@@ -14,7 +14,6 @@ from autochannel.lib.metrics import command_metrics_counter, task_metrics_counte
 from autochannel.data.models import Guild, Category
 
 LOG = logging.getLogger(__name__)
-
 pf = ProfanityFilter(no_word_boundaries = True)
 
 class ACMissingChannel(commands.CommandError):
@@ -48,6 +47,7 @@ class AutoChannels(commands.Cog):
     async def ac_create_channel(self, cat, name=None, **kwargs):
         """
         """
+        time.sleep(1)
         created_channel = await cat.create_voice_channel(name, **kwargs)
         return created_channel
 
@@ -82,6 +82,7 @@ class AutoChannels(commands.Cog):
                     auto_channels = [channel for channel in cat.voice_channels if channel.name.startswith(db_cat.prefix)]
                     for channel in auto_channels:
                         await self.ac_delete_channel(channel, guild=server.name)
+                        time.sleep(2)
             
             categories = [cat for cat in server.categories if cat.id in db_cats]
             """checking if the db knows about the categorey"""
@@ -99,7 +100,7 @@ class AutoChannels(commands.Cog):
                 if empty_channel_count < db_cat.empty_count:
                     while empty_channel_count < db_cat.empty_count:
                         channel_suffix = self.ac_channel_number(auto_channels)
-                        LOG.debug(f' Channel created {db_cat.prefix}')
+                        LOG.debug(f' Channel created {db_cat.prefix}') 
                         position = channel_suffix + len(cat.text_channels)
                         await self.ac_create_channel(cat, name=f'{db_cat.prefix} - {channel_suffix}', guild=server.name, position=position, user_limit=db_cat.channel_size)
                         empty_channel_count += 1
@@ -111,6 +112,7 @@ class AutoChannels(commands.Cog):
                         empty_channel_list.pop(empty_channel_list.index(highest_empty_channel))
                         LOG.debug(f'Deleting too many empty channels form {server.name}: {highest_empty_channel}')
                         await self.ac_delete_channel(highest_empty_channel, guild=server.name)
+                        time.sleep(2)
 
     def ac_highest_empty_channel(self, empty_auto_channels):
         """[summary]

--- a/docker-compose.exporters.yml
+++ b/docker-compose.exporters.yml
@@ -1,0 +1,36 @@
+version: '2.1'
+
+services:
+
+  nodeexporter:
+    image: prom/node-exporter:v0.18.1
+    container_name: nodeexporter
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - '--path.procfs=/host/proc'
+      - '--path.rootfs=/rootfs'
+      - '--path.sysfs=/host/sys'
+      - '--collector.filesystem.ignored-mount-points=^/(sys|proc|dev|host|etc)($$|/)'
+    restart: unless-stopped
+    network_mode: host
+    labels:
+      org.label-schema.group: "monitoring"
+
+  cadvisor:
+    image: google/cadvisor:v0.33.0
+    container_name: cadvisor
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:rw
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /cgroup:/cgroup:ro
+    restart: unless-stopped
+    network_mode: host
+    labels:
+      org.label-schema.group: "monitoring"
+  
+


### PR DESCRIPTION
# What? 
Extra precaution for api limits moderator brought it up. Shouldn't be an issue but we are skating the line and if this hits a bigger server with abusers could be problematic. Enforcing mandatory cooldown on each create/delete to help alleviate the issue 