### PR TITLE
chore: Phase 1 code cleanup (bot fixes + ruff)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ pip-delete-this-directory.txt
 
 # editor
 .vscode
+.ruff-venv/

--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ name = "pypi"
 
 [dev-packages]
 "pep8" = "*"
+ruff = "*"
 
 [packages]
 autochannel = {editable = true, path = "."}

--- a/autochannel/autochannel.py
+++ b/autochannel/autochannel.py
@@ -1,12 +1,7 @@
-import discord
 import logging
-import os
-import asyncio
-import aiohttp
-import json
-from discord.ext.commands import Bot
 
-"""data"""
+import discord
+
 from autochannel.data.database import DB
 
 log = logging.getLogger('discord')
@@ -25,7 +20,6 @@ class AutoChannel(discord.ext.commands.Bot):
         self.app_id = kwargs.get('app_id')
         self.auto_channel_prefix = kwargs.get('auto_channel_prefix')
         self.auto_categories = kwargs.get('auto_categories')
-        self.dbl_token = kwargs.get('dbl_token')
         self.env = kwargs.get('env') or 'dev'
         self.dbl_token = kwargs.get('dbl_token')
         self.stats = None

--- a/autochannel/data/database.py
+++ b/autochannel/data/database.py
@@ -1,15 +1,12 @@
 import os
 from sqlalchemy import create_engine
-from sqlalchemy.orm import Session, sessionmaker
-"""AC imports"""
-from autochannel.data.models import Guild, Category
+from sqlalchemy.orm import sessionmaker
 
 class DB:
     def __init__(self):
         self.engine = create_engine(os.getenv('SQLALCHEMY_DATABASE_URI'))
+        self._session_factory = sessionmaker(bind=self.engine)
 
     def session(self):
-        Session = sessionmaker(bind=self.engine)
-        session = Session()
-        return session
+        return self._session_factory()
 

--- a/autochannel/lib/plugins/autochannels.py
+++ b/autochannel/lib/plugins/autochannels.py
@@ -1,21 +1,17 @@
-import traceback
-
 from typing import Optional
 import asyncio
-import datetime
-from unicodedata import category
-import discord
 import logging
-import queue 
 import random
 import re
 import time
+
+import discord
 from discord import app_commands
 from discord.ext import commands
 from profanityfilter import ProfanityFilter
 """AC imports"""
 from autochannel.lib import utils
-from autochannel.lib.metrics import command_metrics_counter, task_metrics_counter, queue_stats_gauge, COMMAND_SUMMARY_ACUPDATE
+from autochannel.lib.metrics import command_metrics_counter, task_metrics_counter, queue_stats_gauge
 from autochannel.data.models import Guild, Category, Channel
 
 LOG = logging.getLogger(__name__)
@@ -53,8 +49,10 @@ class AutoChannels(commands.Cog):
         self.queue = asyncio.Queue()
         self.next = asyncio.Event()
 
-        self.autochannel.loop.create_task(self.queue_loop())
-        self.autochannel.loop.create_task(self.loop_stats())
+    async def cog_load(self) -> None:
+        loop = asyncio.get_running_loop()
+        loop.create_task(self.queue_loop())
+        loop.create_task(self.loop_stats())
 
     async def loop_stats(self):
         """Loop to track event queue size"""
@@ -226,9 +224,8 @@ class AutoChannels(commands.Cog):
                     try:
                         chan_id_add = Channel(id=chan.id, cat_id=db_cat.id, chan_type='voice', num_suffix=int(self.get_ac_channel(chan)))
                         self.autochannel.session.add(chan_id_add)
-                    except:
+                    except Exception:
                         LOG.info(f'skipping issue for: guild={server.name}, channel={chan.name}')
-                        pass
                 
                 if len(missing_db_channels) > 0:
                     self.autochannel.session.commit()
@@ -339,15 +336,14 @@ class AutoChannels(commands.Cog):
         await interaction.response.send_message("Changes have been syncronized from http://auto-chan.io/")
 
 
-    @sync.error 
+    @sync.error
     async def on_sync_error(self, interaction: discord.Interaction, error: app_commands.AppCommandError) -> None:
-        """_summary_
-
-        Args:
-            interaction (discord.Interaction): _description_
-            error (app_commands.AppCommandError): _description_
-        """
-        await interaction.response.send_message(f"Error {error}")
+        LOG.exception("sync command failed: %s", error)
+        msg = f"Error {error}"
+        if interaction.response.is_done():
+            await interaction.followup.send(msg)
+        else:
+            await interaction.response.send_message(msg)
 
     @app_commands.describe(category='name of category', channel_name='custom name of channel')
     @app_commands.command(name="vc", description="create voice channel")
@@ -382,18 +378,25 @@ class AutoChannels(commands.Cog):
         if not category_obj.custom_enabled:
             raise ACDisabledCustomCategory(f'Category {category_name.name} is disabled. To use custom channels in this category an **ADMIN** must enable:  http://auto-chan.io')
 
-        created_vc= await interaction.guild.create_voice_channel(f'{category_obj.custom_prefix} {vc_suffix}', overwrites={}, category=category_name, reason='AutoChannel bot automation')
+        created_vc = await interaction.guild.create_voice_channel(
+            f'{category_obj.custom_prefix} {vc_suffix}',
+            overwrites={},
+            category=category_name,
+            reason='AutoChannel bot automation',
+        )
         invite_link = await self.createVCInvite(interaction, created_vc)
 
-        await interaction.channel.send(f'AutoChannel made `{interaction.user}` a channel `{created_vc.name}`')
         await interaction.response.send_message(invite_link)
+        if interaction.channel is not None:
+            await interaction.channel.send(
+                f'AutoChannel made `{interaction.user}` a channel `{created_vc.name}`'
+            )
 
         await asyncio.sleep(60)
-        if  len(created_vc.members) < 1:
+        if len(created_vc.members) < 1:
             try:
                 await self.vc_delete_channel(created_vc, reason='No one joined the custom channel after 60 seconds')
-            except:
-                """annoying to see this error doesn't add value to the end user"""
+            except Exception:
                 pass
 
 
@@ -424,23 +427,22 @@ class AutoChannels(commands.Cog):
             for category in categories if current.lower() in category.lower()
         ]
 
-    @vc.error 
+    @vc.error
     async def on_vc_error(self, interaction: discord.Interaction, error: app_commands.AppCommandError):
-        """_summary_
-
-        Args:
-            interaction (discord.Interaction): _description_
-            error (app_commands.AppCommandError): _description_
-        """        
-        msg = error
+        LOG.exception("vc command failed: %s", error)
+        msg = str(error)
         if isinstance(error, ACUnknownCategory):
-            existing_cats = self.cat_names(ctx)
-            msg += f'**Unknown category:** How-To: `!vc <category> <name of channel>`   **Category list:** {existing_cats}'
-        if isinstance(error, VCProfaneWordused):
-            msg += 'Auto-chan hates bad words, please be nice'
-            
-        traceback.print_exc()
-        await interaction.response.send_message(msg)
+            existing_cats = ', '.join(self.getGuildCategories(interaction))
+            msg = (
+                f'{msg} **Unknown category:** How-To: `/vc <category> <name of channel>` '
+                f'**Category list:** {existing_cats}'
+            )
+        elif isinstance(error, VCProfaneWordused):
+            msg += ' Auto-chan hates bad words, please be nice'
+        if interaction.response.is_done():
+            await interaction.followup.send(msg)
+        else:
+            await interaction.response.send_message(msg)
 
 
     def valid_auto_channel(self, v_state: discord.VoiceState) -> bool:

--- a/autochannel/lib/plugins/server.py
+++ b/autochannel/lib/plugins/server.py
@@ -21,20 +21,21 @@ class Server(commands.Cog):
         self.autochannel.loop.create_task(utils.list_servers(self.autochannel))
         self.autochannel.loop.create_task(utils.list_users(self.autochannel))
 
+    @commands.Cog.listener()
     async def on_command_error(self, ctx, error):
+        msg = None
         if isinstance(error, commands.CommandInvokeError):
             LOG.error(error)
             msg = '{} Error running the command'.format(ctx.message.author.mention)
-        if isinstance(error, commands.CommandNotFound):
+        elif isinstance(error, commands.CommandNotFound):
             msg = '{} the command you ran does not exist please use !help for assistance'.format(ctx.message.author.mention)
-        if isinstance(error, commands.CheckFailure):
+        elif isinstance(error, commands.CheckFailure):
             msg = ':octagonal_sign: you do not have permission to run this command, {}'.format(ctx.message.author.mention)
-        if isinstance(error, commands.MissingRequiredArgument):
+        elif isinstance(error, commands.MissingRequiredArgument):
             msg = 'Missing required argument: ```{}```'.format(error)
 
-        if not msg:
+        if msg is None:
             msg = 'Oh no, I have no idea what I am doing! {}'.format(error)
-
 
         await ctx.send('{}'.format(msg))
 

--- a/autochannel/lib/utils.py
+++ b/autochannel/lib/utils.py
@@ -147,7 +147,7 @@ async def list_users(client):
     """
     await client.wait_until_ready()
     while not client.is_closed():
-        numb_of_clients = len(set(client.get_all_members()))
+        numb_of_clients = len(client.users)
         bot_user_count(numb_of_clients)
         LOG.debug(f'Number Of clients: {numb_of_clients}')
         await asyncio.sleep(600)

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,8 @@
+target-version = "py310"
+line-length = 100
+src = ["autochannel"]
+
+[lint]
+select = ["E9", "F"]
+# Legacy codebase: import placement and unused imports addressed gradually
+ignore = ["E402", "F401", "F541"]

--- a/setup.py
+++ b/setup.py
@@ -7,15 +7,11 @@ import autochannel
 INSTALL_REQUIREMENTS = [
     # 'aiohttp==3.6.3',
     'aiohttp',
-    'asyncio',
     'aiomeasures',
     'coloredlogs',
     'dblpy',
     'discord.py==2.3.2',
-    'dblpy',
     'flask_sqlalchemy',
-    # 'pip==18.0',
-    'pip',
     'profanityfilter',
     'prometheus_client',
     'psycopg2-binary',
@@ -30,7 +26,10 @@ TEST_REQUIREMENTS = {
         'pytest',
         'pylint',
         'sure',
-        ]
+        ],
+    'dev': [
+        'ruff',
+    ],
     }
 
 setup(


### PR DESCRIPTION
## Summary
Phase 1 modernization: bug fixes and lint tooling without dependency upgrades.

## Changes
- Fix `/vc` slash flow: respond to the interaction before posting to the channel; fix `on_vc_error` (correct category list, followup when already responded); align `sync` error handling.
- Schedule queue/loop tasks from `cog_load` via `asyncio.get_running_loop()`.
- Register `Server.on_command_error` as a cog listener; use `elif` and initialize `msg`.
- `DB`: cache a single SQLAlchemy `sessionmaker` instead of creating one per call.
- `utils.list_users`: use `len(client.users)` instead of removed `get_all_members()`.
- `setup.py`: remove invalid `asyncio`/`pip` deps and duplicate `dblpy` entry.
- Add `autochannel/data/__init__.py`, `ruff.toml`, dev `ruff` extra, `.gitignore` `.ruff-venv/`.

## Test
- `pip install -e ".[dev]"` then `ruff check autochannel setup.py`
- Run bot in a test guild; exercise `/sync` and `/vc` where applicable.

Made with [Cursor](https://cursor.com)